### PR TITLE
feat: add workdir options

### DIFF
--- a/cmd/regctl/image.go
+++ b/cmd/regctl/image.go
@@ -271,6 +271,10 @@ regctl image mod registry.example.org/repo:v1 --create v1-extended \
 regctl image mod registry.example.org/repo:v1 --create v1-extended \
   --layer-add "dir=path/to/directory"
 
+# append a layer to all platforms using the contents of a directory with a different workdir
+regctl image mod registry.example.org/repo:v1 --create v1-extended \
+  --layer-add "dir=path/to/directory,workdir=/tmp"
+
 # set the timestamp on the config and layers, ignoring the alpine base image layers
 regctl image mod registry.example.org/repo:v1 --create v1-mod \
   --time "set=2021-02-03T04:05:06Z,base-ref=alpine:3"

--- a/cmd/regctl/image_test.go
+++ b/cmd/regctl/image_test.go
@@ -196,6 +196,11 @@ func TestImageMod(t *testing.T) {
 			expectOut: modRef,
 		},
 		{
+			name:      "layer-add-dir-workdir",
+			cmd:       []string{"image", "mod", srcRef, "--create", modRef, "--layer-add", "dir=../../cmd,workdir=/tmp"},
+			expectOut: modRef,
+		},
+		{
 			name:      "layer-add-both",
 			cmd:       []string{"image", "mod", srcRef, "--create", modRef, "--layer-add", "tar=../../testdata/layer.tar,dir=../../cmd,platform=linux/amd64"},
 			expectErr: fmt.Errorf(`invalid argument "tar=../../testdata/layer.tar,dir=../../cmd,platform=linux/amd64" for "--layer-add" flag: cannot use dir and tar options together in layer-add`),

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -19,6 +19,8 @@ type TarOpts func(*tarOpts)
 type tarOpts struct {
 	// allowRelative bool // allow relative paths outside of target folder
 	compress string
+	// workPath is like Dockerfile WORKDIR, it sets the base path for the tar
+	workPath string
 }
 
 // TarCompressGzip option to use gzip compression on tar files
@@ -31,6 +33,13 @@ func TarUncompressed(to *tarOpts) {
 }
 
 // TODO: add option for full path or to adjust the relative path
+func TarWorkPath(workPath string) TarOpts {
+	return func(to *tarOpts) {
+		if workPath != "" {
+			to.workPath = workPath
+		}
+	}
+}
 
 // Tar creation
 func Tar(ctx context.Context, path string, w io.Writer, opts ...TarOpts) error {
@@ -64,6 +73,10 @@ func Tar(ctx context.Context, path string, w io.Writer, opts ...TarOpts) error {
 		relPath, err := filepath.Rel(path, file)
 		if err != nil || relPath == "." {
 			return nil
+		}
+
+		if to.workPath != "" {
+			relPath = filepath.Join(to.workPath, relPath)
 		}
 
 		header, err := tar.FileInfoHeader(fi, relPath)


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->
New feature: Add support for setting workdir in regctl's --layer-add option

This change extends the functionality of the `--layer-add` option in regctl to allow users to specify a working directory (workdir) when adding a new layer. This enhancement provides more flexibility in setting the working directory for added content when modifying images.

The implementation involves:
1. Extending the parameter parsing for the `--layer-add` option to support a `workdir` parameter.
2. Modifying the layer addition logic to set the specified `workdir` for the new layer.

### How to verify it

<!-- Include steps that can be taken to verify the change -->
1. Use regctl to modify an image with the new `--layer-add` syntax:
   ```
   regctl image mod <source_image>:<tag> \
     --create <destination_image>:<tag> \
     --layer-add "dir=/path/to/source,workdir=/custom/workdir" \
     -v debug
   ```
2. Inspect the resulting image to confirm that the working directory is correctly set to `/custom/workdir` for the new layer.
3. Test with various source directories and workdir paths to ensure the feature works as expected.

### Changelog text

<!-- If the release changelog should have an entry for this, include it here -->
Added support for setting workdir in `--layer-add` option, allowing users to specify a working directory for the new layer when modifying images.

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [x] Tests have been added or not applicable
- [x] Documentation has been added, updated, or not applicable
- [x] Changes have been rebased to main
- [x] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->